### PR TITLE
add z-indexes for modal

### DIFF
--- a/packages/ui-kit/src/components/modal/modal.module.scss
+++ b/packages/ui-kit/src/components/modal/modal.module.scss
@@ -1,12 +1,15 @@
 .overlay {
   position: fixed;
+  z-index: 100;
   inset: 0;
+
   background-color: rgb(0 0 0 / 50%);
   backdrop-filter: blur(4px);
 }
 
 .content {
   position: fixed;
+  z-index: 101;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
- добавляет z-index для Modal

Причина: в ЛК Header перекрывает overlay модалок (у него z-index: 20)