### PR TITLE
romove backdrop-filter for modal overlay

### DIFF
--- a/packages/ui-kit/src/components/modal/modal.module.scss
+++ b/packages/ui-kit/src/components/modal/modal.module.scss
@@ -2,9 +2,7 @@
   position: fixed;
   z-index: 100;
   inset: 0;
-
   background-color: rgb(0 0 0 / 50%);
-  backdrop-filter: blur(4px);
 }
 
 .content {


### PR DESCRIPTION
- удаляет свойство backdrop-filter для overlay модальных окон

Причина:  очень плохая производительности и заметные баги анимации при ховерах на элементах и при использовании селектов. Backdrop filters/blurs - чрезвычайно дорогое по ресурсам свойство