### PR TITLE
add tooltip component prop

### DIFF
--- a/packages/ui-kit/src/components/dropdown/index.tsx
+++ b/packages/ui-kit/src/components/dropdown/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ComponentPropsWithoutRef, CSSProperties, FC, ReactNode } from 'react'
+import { ComponentPropsWithoutRef, CSSProperties, FC, ReactNode } from 'react'
 
 import * as DropdownMenuRadix from '@radix-ui/react-dropdown-menu'
 import { clsx } from 'clsx'

--- a/packages/ui-kit/src/components/tooltip/index.tsx
+++ b/packages/ui-kit/src/components/tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ComponentProps, FC, ReactNode } from 'react'
 
 import * as TooltipRadix from '@radix-ui/react-tooltip'
 
@@ -6,12 +6,24 @@ import { InfoOutline } from '../../'
 
 import s from './tooltip.module.scss'
 
-export type TooltipProps = {
+type CommonProps = {
   children: ReactNode
-  icon?: ReactNode
-}
+  side?: 'top' | 'right' | 'bottom' | 'left'
+} & ComponentProps<'div'>
 
-export const Tooltip: FC<TooltipProps> = ({ children, icon }) => {
+type ConditionalProps =
+  | {
+      icon?: ReactNode
+      component?: never
+    }
+  | {
+      icon?: never
+      component?: ReactNode
+    }
+
+export type TooltipProps = CommonProps & ConditionalProps
+
+export const Tooltip: FC<TooltipProps> = ({ children, icon, side = 'top', component, ...rest }) => {
   const classNames = {
     content: s.content,
     iconButton: s.iconButton,
@@ -20,24 +32,32 @@ export const Tooltip: FC<TooltipProps> = ({ children, icon }) => {
     infoIcon: s.infoIcon,
   }
 
-  const tooltipIcon = icon ? (
-    icon
-  ) : (
-    <span className={s.infoIcon}>
-      <InfoOutline size={16} />
-    </span>
-  )
+  let tooltipTrigger: ReactNode
+
+  if (component) {
+    tooltipTrigger = <span>{component}</span>
+  } else {
+    tooltipTrigger = (
+      <button className={classNames.iconButton}>
+        {icon ? (
+          icon
+        ) : (
+          <span className={s.infoIcon}>
+            <InfoOutline size={16} />
+          </span>
+        )}
+      </button>
+    )
+  }
 
   const DELAY_DURATION = 200
 
   return (
-    <TooltipRadix.Provider delayDuration={DELAY_DURATION}>
+    <TooltipRadix.Provider delayDuration={DELAY_DURATION} {...rest}>
       <TooltipRadix.Root>
-        <TooltipRadix.Trigger asChild>
-          <button className={classNames.iconButton}>{tooltipIcon}</button>
-        </TooltipRadix.Trigger>
+        <TooltipRadix.Trigger asChild>{tooltipTrigger}</TooltipRadix.Trigger>
         <TooltipRadix.Portal>
-          <TooltipRadix.Content className={classNames.content} sideOffset={4}>
+          <TooltipRadix.Content className={classNames.content} sideOffset={4} side={side}>
             {children}
             <TooltipRadix.Arrow className={classNames.arrowBox} asChild>
               <div className={classNames.arrow} />

--- a/packages/ui-kit/stories/components/disclosure/dropdown/dropdown.stories.tsx
+++ b/packages/ui-kit/stories/components/disclosure/dropdown/dropdown.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/react'
 
-import { Dropdown, ToolbarItemWithIcon, DeleteForever, Edit } from '../../../../src'
+import { Dropdown, ToolbarItemWithIcon, DeleteForever, Edit, Tooltip } from '../../../../src'
 import { useDarkMode } from '../../../../storybook-utils/hooks/use-dark-mode'
 
 export default {
@@ -49,12 +49,19 @@ export const WithDisabledItem = {
     children: (
       <>
         <ToolbarItemWithIcon icon={<Edit />} text="Изменить" onSelect={() => {}} />
-        <ToolbarItemWithIcon
-          icon={<DeleteForever />}
-          text="Удалить"
-          onSelect={() => {}}
-          disabled={true}
-        />
+        <Tooltip
+          component={
+            <ToolbarItemWithIcon
+              icon={<DeleteForever />}
+              text="Удалить"
+              onSelect={() => {}}
+              disabled={true}
+            />
+          }
+          side="bottom"
+        >
+          Для удаления необходимо удалить все дочерние узлы
+        </Tooltip>
       </>
     ),
   },

--- a/packages/ui-kit/stories/components/disclosure/tooltip/tooltip.stories.tsx
+++ b/packages/ui-kit/stories/components/disclosure/tooltip/tooltip.stories.tsx
@@ -35,3 +35,10 @@ export const DefaultWithCustomIcon = {
     icon: <ThumbUp size={16} />,
   },
 }
+
+export const DefaultWithComponent = {
+  args: {
+    component: <span>text</span>,
+    ...Light.args,
+  },
+}


### PR DESCRIPTION
- Добавляет возможность передавать в тулпит не только иконки, но и компоненты

Пример использования в дизайне:
![image](https://user-images.githubusercontent.com/57465500/230718687-ba57020c-67a0-4d2c-994e-8636d690eaec.png)
