### PR TITLE
UIl-94: update Tooltip and Combobox

### DIFF
--- a/packages/ui-kit/src/components/combobox/index.tsx
+++ b/packages/ui-kit/src/components/combobox/index.tsx
@@ -26,7 +26,7 @@ export type ComboboxProps = {
   /** The name of the select. Submitted with its owning form as part of a name/value pair. */
   name?: string
   /** The function to call when a new option is selected. */
-  onChange: (value: null | string) => void
+  onChange: (value: null | number | string) => void
   onClear?: () => void
   onInputChange: (value: string) => void
   /** The options to display.
@@ -35,7 +35,7 @@ export type ComboboxProps = {
   placeholder?: string
   portal?: boolean
   showClearButton?: boolean
-  value: string
+  value: null | number | string
 }
 
 export const Combobox: FC<ComboboxProps> = ({

--- a/packages/ui-kit/src/components/tooltip/index.tsx
+++ b/packages/ui-kit/src/components/tooltip/index.tsx
@@ -10,6 +10,8 @@ import s from './tooltip.module.scss'
 type CommonProps = {
   children: ReactNode
   contentClassName?: string
+  /** Prevents Tooltip.Content from remaining open when hovering */
+  disableHoverableContent?: boolean
   side?: 'bottom' | 'left' | 'right' | 'top'
 } & ComponentProps<'div'>
 

--- a/packages/ui-kit/stories/components/disclosure/tooltip/tooltip.stories.tsx
+++ b/packages/ui-kit/stories/components/disclosure/tooltip/tooltip.stories.tsx
@@ -47,3 +47,10 @@ export const DefaultWithComponent = {
     component: <span>text</span>,
   },
 }
+
+export const WithDisableHoverableContent = {
+  args: {
+    ...DefaultWithComponent.args,
+    disableHoverableContent: true,
+  },
+}


### PR DESCRIPTION
- добавляет проп `disableHoverableContent` для Tooltip: позволяет отключать всплывающее окно
- исправляет типизацию Combobox, позволяя передавать в качестве значений null и number