### PR TITLE
UIl-95

### DIFF
--- a/.changeset/flat-windows-think.md
+++ b/.changeset/flat-windows-think.md
@@ -1,0 +1,6 @@
+---
+"@it-incubator/ui-kit": patch
+---
+
+use render props for AnimatedIcon, use generic for typing Combobox props
+  

--- a/packages/ui-kit/src/components/animated-icon/animated-icon.tsx
+++ b/packages/ui-kit/src/components/animated-icon/animated-icon.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ComponentType } from 'react'
+import { ComponentPropsWithoutRef, ReactElement } from 'react'
 
 import { InfoOutline } from '../../assets/icons'
 import { IconProps } from '../../assets/icons/IconWrapper'
@@ -7,10 +7,10 @@ import { motion } from 'framer-motion'
 import s from './animated-icon.module.scss'
 
 export type AnimatedIconProps = {
-  Icon: ComponentType<IconProps>
-  enableAnimation: boolean
+  enableAnimation?: boolean
+  renderIcon: (props: IconProps) => ReactElement
 } & ComponentPropsWithoutRef<typeof InfoOutline>
-export const AnimatedIcon = ({ Icon, enableAnimation, ...iconProps }: AnimatedIconProps) => {
+export const AnimatedIcon = ({ enableAnimation = true, renderIcon }: AnimatedIconProps) => {
   const duration = 1.4
   const initial = { x: '-50%', y: '-50%' }
   const transition = { duration, repeat: Infinity, type: 'keyframes' }
@@ -43,13 +43,12 @@ export const AnimatedIcon = ({ Icon, enableAnimation, ...iconProps }: AnimatedIc
           ></motion.div>
         </>
       )}
-      <Icon
-        backgroundColor={'transparent'}
-        className={s.icon}
-        color={'var(--color-text-primary)'}
-        size={16}
-        {...iconProps}
-      />
+      {renderIcon({
+        backgroundColor: 'transparent',
+        className: s.icon,
+        color: 'var(--color-text-primary)',
+        size: 16,
+      })}
     </div>
   )
 }

--- a/packages/ui-kit/src/components/animated-info-icon/animated-info-icon.tsx
+++ b/packages/ui-kit/src/components/animated-info-icon/animated-info-icon.tsx
@@ -7,5 +7,11 @@ export type AnimatedInfoIconProps = { enableAnimation: boolean } & ComponentProp
   typeof InfoOutline
 >
 export const AnimatedInfoIcon = ({ enableAnimation, ...iconProps }: AnimatedInfoIconProps) => {
-  return <AnimatedIcon Icon={InfoOutline} enableAnimation={enableAnimation} {...iconProps} />
+  return (
+    <AnimatedIcon
+      enableAnimation={enableAnimation}
+      renderIcon={props => <InfoOutline {...props} />}
+      {...iconProps}
+    />
+  )
 }

--- a/packages/ui-kit/src/components/combobox/index.tsx
+++ b/packages/ui-kit/src/components/combobox/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, Fragment, MouseEventHandler } from 'react'
+import { ChangeEvent, Fragment, MouseEventHandler } from 'react'
 
 import { Close, KeyboardArrowDown, Scrollbar, Spinner, Typography } from '../../'
 import { Label } from '../label'
@@ -10,12 +10,12 @@ import selectStyle from '../select/select.module.scss'
 import textFieldStyle from '../text-field/text-field.module.scss'
 import s from './combobox.module.scss'
 
-type Option = {
+type Option<T> = {
   label: string
-  value: number | string
+  value: T
 }
 
-export type ComboboxProps = {
+export type ComboboxProps<T> = {
   disabled?: boolean
   errorMessage?: string
   /** The value displayed in the textbox */
@@ -26,19 +26,19 @@ export type ComboboxProps = {
   /** The name of the select. Submitted with its owning form as part of a name/value pair. */
   name?: string
   /** The function to call when a new option is selected. */
-  onChange: (value: null | number | string) => void
+  onChange: (value: T | null) => void
   onClear?: () => void
   onInputChange: (value: string) => void
   /** The options to display.
    * {label: string, value: string | number} */
-  options: Option[]
+  options: Option<T>[]
   placeholder?: string
   portal?: boolean
   showClearButton?: boolean
-  value: null | number | string
+  value: T | null
 }
 
-export const Combobox: FC<ComboboxProps> = ({
+export const Combobox = <T extends number | string>({
   disabled,
   errorMessage,
   inputValue,
@@ -54,7 +54,7 @@ export const Combobox: FC<ComboboxProps> = ({
   portal = true,
   showClearButton = true,
   value,
-}) => {
+}: ComboboxProps<T>) => {
   const showError = !!errorMessage && errorMessage.length > 0
   const isClearButtonVisible = showClearButton && !!value
   const inputChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {

--- a/packages/ui-kit/src/components/tooltip/index.tsx
+++ b/packages/ui-kit/src/components/tooltip/index.tsx
@@ -42,6 +42,7 @@ export const Tooltip = ({
   children,
   component,
   contentClassName,
+  disableHoverableContent,
   icon,
   side = 'top',
   ...props
@@ -74,7 +75,11 @@ export const Tooltip = ({
 
   return (
     <TooltipRadix.Provider delayDuration={DELAY_DURATION} {...props}>
-      <TooltipRadix.Root onOpenChange={setOpen} open={open}>
+      <TooltipRadix.Root
+        disableHoverableContent={disableHoverableContent}
+        onOpenChange={setOpen}
+        open={open}
+      >
         <TooltipRadix.Trigger asChild>{tooltipTrigger}</TooltipRadix.Trigger>
         <AnimatePresence>
           {open && (

--- a/packages/ui-kit/stories/components/feedback/animated-icon/animated-icon.stories.tsx
+++ b/packages/ui-kit/stories/components/feedback/animated-icon/animated-icon.stories.tsx
@@ -11,23 +11,20 @@ type Story = StoryObj<typeof AnimatedIcon>
 
 export const Default: Story = {
   args: {
-    Icon: InfoOutline,
     enableAnimation: true,
+    renderIcon: props => <InfoOutline {...props} />,
   },
 }
 
 export const AnimationDisabled: Story = {
   args: {
-    Icon: InfoOutline,
     enableAnimation: false,
+    renderIcon: props => <InfoOutline {...props} />,
   },
 }
 
 export const WithCustomSizeAndColor: Story = {
   args: {
-    Icon: Edit,
-    color: 'var(--color-danger-400)',
-    enableAnimation: true,
-    size: 25,
+    renderIcon: props => <Edit {...props} color={'var(--color-danger-400)'} size={25} />,
   },
 }

--- a/packages/ui-kit/stories/components/feedback/animated-info-icon/animated-info-icon.stories.tsx
+++ b/packages/ui-kit/stories/components/feedback/animated-info-icon/animated-info-icon.stories.tsx
@@ -1,0 +1,16 @@
+import { AnimatedInfoIcon } from '../../../../src'
+import { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  component: AnimatedInfoIcon,
+  title: 'Components/Feedback/AnimatedInfoIcon',
+} satisfies Meta<typeof AnimatedInfoIcon>
+
+export default meta
+type Story = StoryObj<typeof AnimatedInfoIcon>
+
+export const Default: Story = {
+  args: {
+    enableAnimation: true,
+  },
+}


### PR DESCRIPTION
- использует render props в AnimatedIcon
Почему-то один из микрофронтендов выдаёт ошибку при использовании компонента AnimatedIcon (в других проектах всё хорошо): `cannot read properties of undefined (reading 'getStackAddendum')`  - информации по ней почти нет(возможно, что-то с react-scripts). Не уверен, что это решит проблему

- в Tooltip переносит проп disableHoverableContent из Tooltip.Provider в Tooltip.Root. Почему-то предыдущая реализация работает только в Storybook

- исправляет типизацию в Combobox, используя Generic Type