### PR TITLE
Refactor: label type in props

### DIFF
--- a/packages/ui-kit/src/components/select/index.tsx
+++ b/packages/ui-kit/src/components/select/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, FC, Fragment, useMemo } from 'react'
+import { CSSProperties, FC, Fragment, ReactNode, useMemo } from 'react'
 
 import { KeyboardArrowDown, Typography } from '../../'
 import { Label } from '../label'
@@ -20,7 +20,7 @@ interface CommonProps {
   className?: string
   disabled?: boolean
   errorMessage?: string
-  label?: string
+  label?: ReactNode
   /** The name of the select. Submitted with its owning form as part of a name/value pair. */
   name?: string
   /** The options to display.

--- a/packages/ui-kit/src/components/textarea/index.tsx
+++ b/packages/ui-kit/src/components/textarea/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ComponentProps, forwardRef } from 'react'
+import { ChangeEvent, ComponentProps, ReactNode, forwardRef } from 'react'
 
 import { Label } from '../label'
 import { useGetId } from '../text-field/useGetId'
@@ -9,7 +9,7 @@ import s from './textarea.module.scss'
 
 export type TextareaProps = {
   errorMessage?: string
-  label?: string
+  label?: ReactNode
   onValueChange?: (text: string) => void
 } & ComponentProps<'textarea'>
 


### PR DESCRIPTION
Changes "label" type to ReactNode for Select and Textarea to allow passing nodes instead of strings