### PR TITLE
Fix: add button type for components

### DIFF
--- a/packages/ui-kit/src/components/date-picker/index.tsx
+++ b/packages/ui-kit/src/components/date-picker/index.tsx
@@ -144,7 +144,7 @@ const CustomHeader = ({ date, decreaseMonth, increaseMonth }: ReactDatePickerCus
           <KeyboardArrowLeft />
         </button>
 
-        <button className={classNames.button} onClick={increaseMonth}>
+        <button className={classNames.button} onClick={increaseMonth} type={'button'}>
           <KeyboardArrowRight />
         </button>
       </div>

--- a/packages/ui-kit/src/components/file-upload-preview/file-upload-preview.tsx
+++ b/packages/ui-kit/src/components/file-upload-preview/file-upload-preview.tsx
@@ -68,7 +68,7 @@ export const FileUploadPreview = ({ files, onFileDelete }: FileUploadPreviewProp
               <Progress baseColor={'var(--color-upload-progress)'} height={'3px'} />
               <Typography.Body2 className={s.fileSize}>{getFileSize(file.size)}</Typography.Body2>
             </div>
-            <button className={s.cancelButton} onClick={() => handleFileDelete(file)}>
+            <button className={s.cancelButton} onClick={() => handleFileDelete(file)} type={'button'}>
               <Cancel />
             </button>
           </div>

--- a/packages/ui-kit/src/components/read-more/index.tsx
+++ b/packages/ui-kit/src/components/read-more/index.tsx
@@ -33,7 +33,7 @@ export const ReadMore: FC<ReadMoreProps> = ({
   return (
     <>
       {textToShow}
-      <button className={s.button} onClick={toggleReadMore}>
+      <button className={s.button} onClick={toggleReadMore} type={'button'}>
         {buttonText}
       </button>
     </>

--- a/packages/ui-kit/src/components/tooltip/index.tsx
+++ b/packages/ui-kit/src/components/tooltip/index.tsx
@@ -63,7 +63,7 @@ export const Tooltip = ({
     tooltipTrigger = <span>{component}</span>
   } else {
     tooltipTrigger = (
-      <button className={classNames.iconButton}>
+      <button className={classNames.iconButton} type='button'>
         {icon ?? (
           <span className={s.infoIcon}>
             <InfoOutline size={16} />

--- a/packages/ui-kit/src/components/tooltip/index.tsx
+++ b/packages/ui-kit/src/components/tooltip/index.tsx
@@ -63,7 +63,7 @@ export const Tooltip = ({
     tooltipTrigger = <span>{component}</span>
   } else {
     tooltipTrigger = (
-      <button className={classNames.iconButton} type='button'>
+      <button className={classNames.iconButton} type={'button'}>
         {icon ?? (
           <span className={s.infoIcon}>
             <InfoOutline size={16} />


### PR DESCRIPTION
В компоненте `Tooltip`, при его использовании без атрибута `component`, рендерится базовый тег `button`. В этом теге не указан явно атрибут `type`, что может привести к тому, что при использовании компонента внутри формы, нажав на `Tooltip`, пользователь может отправить форму.

Явное указание атрибута `type` для тега `button` внутри компонента решает эту проблему.

Та же проблема относится к компонентам `ReadMore`, `FileUploadPreview`, `DatePicker`, которые могут быть частью формы.