### PR TITLE
chore: restrict perfectionist to sort imports only

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @it-incubator/eslint-config-incubator
 
+## 1.0.4
+### Patch Changes
+
+- restricted perfectionist to sort imports only
+
 ## 1.0.3
 ### Patch Changes
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -14,7 +14,6 @@ module.exports = {
     'plugin:import/recommended',
     'plugin:import/typescript',
     'plugin:prettier/recommended',
-    'plugin:perfectionist/recommended-natural',
   ],
   overrides: [
     {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@it-incubator/eslint-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "index.js",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
- ограничивает использование плагина perfectionist исключительно сортировкой импортов